### PR TITLE
chore: set up Rstack pre-commit hooks

### DIFF
--- a/.rstack/hooks/pre-commit
+++ b/.rstack/hooks/pre-commit
@@ -1,0 +1,1 @@
+rs staged

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev": "rs lib -w",
     "format": "rs fmt",
     "lint": "rs lint",
+    "prepare": "rs setup",
     "test": "rs test"
   },
   "devDependencies": {

--- a/playground/rstack.config.ts
+++ b/playground/rstack.config.ts
@@ -1,3 +1,4 @@
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
 
 define.app(async () => {

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -1,13 +1,19 @@
+// Configuration guide: https://rstack.rs/config
 import { define } from 'rstack';
+
+define.lib({
+  dts: true,
+  syntax: 'es2023',
+});
 
 define.fmt({
   singleQuote: true,
   sortPackageJson: true,
 });
 
-define.lib({
-  dts: true,
-  syntax: 'es2023',
+define.staged({
+  '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint', 'rs fmt'],
+  '*.{json,md,mdx,css,sass,scss,less,html,yml,yaml}': 'rs fmt',
 });
 
 define.lint(({ globals, js, ts }) => [

--- a/rstack.config.ts
+++ b/rstack.config.ts
@@ -13,7 +13,7 @@ define.fmt({
 
 define.staged({
   '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}': ['rs lint', 'rs fmt'],
-  '*.{json,md,mdx,css,sass,scss,less,html,yml,yaml}': 'rs fmt',
+  '*.{json,md,mdx,css,scss,less,html,yml,yaml}': 'rs fmt',
 });
 
 define.lint(({ globals, js, ts }) => [


### PR DESCRIPTION
This PR enables repository-managed pre-commit checks so staged changes are linted and formatted consistently.

It adds the Rstack staged-file configuration and hook, runs `rs setup` during prepare, and links the configuration guide.